### PR TITLE
Add go to summary slide hotspot button in answer hotspot picker

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/af.json
+++ b/language/af.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/ar.json
+++ b/language/ar.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/bg.json
+++ b/language/bg.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/bs.json
+++ b/language/bs.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/ca.json
+++ b/language/ca.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/cs.json
+++ b/language/cs.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/da.json
+++ b/language/da.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/de.json
+++ b/language/de.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/el.json
+++ b/language/el.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/es.json
+++ b/language/es.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/et.json
+++ b/language/et.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/eu.json
+++ b/language/eu.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/fi.json
+++ b/language/fi.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/fr.json
+++ b/language/fr.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/gl.json
+++ b/language/gl.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/he.json
+++ b/language/he.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/id.json
+++ b/language/id.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/it.json
+++ b/language/it.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/ja.json
+++ b/language/ja.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/km.json
+++ b/language/km.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/ko.json
+++ b/language/ko.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/nb.json
+++ b/language/nb.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "Ingen handling"
+                        },
+                        {
+                          "label": "Gå til oppsummeringsslide"
                         }
                       ]
                     },

--- a/language/nl.json
+++ b/language/nl.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/nn.json
+++ b/language/nn.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "Ingen handling"
+                        },
+                        {
+                          "label": "Gå til lysbilete med samandrag"
                         }
                       ]
                     },

--- a/language/pl.json
+++ b/language/pl.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/pt.json
+++ b/language/pt.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/ru.json
+++ b/language/ru.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/sl.json
+++ b/language/sl.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/sma.json
+++ b/language/sma.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/sme.json
+++ b/language/sme.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/smj.json
+++ b/language/smj.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/sv.json
+++ b/language/sv.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/tr.json
+++ b/language/tr.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/uk.json
+++ b/language/uk.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/language/zh.json
+++ b/language/zh.json
@@ -104,6 +104,9 @@
                         },
                         {
                           "label": "No action"
+                        },
+                        {
+                          "label": "Go to summary slide"
                         }
                       ]
                     },

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "contentType": "Library",
   "majorVersion": 1,
   "minorVersion": 24,
-  "patchVersion": 9,
+  "patchVersion": 10,
   "runnable": 1,
   "fullscreen": 1,
   "embedTypes": [

--- a/semantics.json
+++ b/semantics.json
@@ -188,11 +188,31 @@
                     "spectrum": {
                       "showPalette": true,
                       "palette": [
-                            ["#1d5cff", "black", "white", "gray"],
-                            ["red", "blue", "yellow", "green"],
-                            ["pink", "purple", "brown", "orange"],
-                            ["lime", "violet", "magenta", "cyan"]
+                        [
+                          "#1d5cff",
+                          "black",
+                          "white",
+                          "gray"
+                        ],
+                        [
+                          "red",
+                          "blue",
+                          "yellow",
+                          "green"
+                        ],
+                        [
+                          "pink",
+                          "purple",
+                          "brown",
+                          "orange"
+                        ],
+                        [
+                          "lime",
+                          "violet",
+                          "magenta",
+                          "cyan"
                         ]
+                      ]
                     }
                   },
                   {
@@ -307,6 +327,10 @@
                       {
                         "value": "none",
                         "label": "No action"
+                      },
+                      {
+                        "value": "go-to-summary-slide",
+                        "label": "Go to summary slide"
                       }
                     ],
                     "default": "specified",

--- a/src/scripts/answer-hotspot.js
+++ b/src/scripts/answer-hotspot.js
@@ -15,7 +15,6 @@ export function initAnswerHotspot(element, answerType) {
 
   const checkedClass = "h5p-hotspot-answer--checked";
   element.$element.on("click", () => {
-
     const wasChecked = element.isChecked;
     if (wasChecked) {
       element.$element.removeClass(checkedClass);
@@ -24,13 +23,12 @@ export function initAnswerHotspot(element, answerType) {
     }
 
     element.isChecked = !wasChecked;
-
   });
-  
+
   element.resetTask = () => {
     element.isChecked = false;
     element.$element.removeClass(checkedClass);
-  }
+  };
 
   element.isTask = true;
   element.answerHotspotType = answerType;

--- a/src/scripts/element.js
+++ b/src/scripts/element.js
@@ -45,7 +45,7 @@ function Element(parameters) {
 
   const isAnswerHotspot = !!answerType;
   if (isAnswerHotspot) {
-    Element.registerAnswerHotspot(this.instance, answerType);
+    initAnswerHotspot(this.instance, answerType);
   }
 
   const slideHasElements = !!coursePresentation.elementInstances[slide.index];
@@ -228,18 +228,13 @@ Element.createHotspot = function (
       const index = event.data;
       coursePresentation.jumpToSlide(index);
     });
+
+    hotspot.on("navigate-to-last-slide", () => {
+      coursePresentation.jumpToSlide(coursePresentation.slides.length - 1);
+    })
   }
 
   return hotspot;
-};
-
-/**
- *
- * @param {Hotspot} instance
- * @param {"true" | "false"} answerType
- */
-Element.registerAnswerHotspot = function (instance, answerType) {
-  initAnswerHotspot(instance, answerType);
 };
 
 export default Element;

--- a/src/scripts/hotspot.js
+++ b/src/scripts/hotspot.js
@@ -15,6 +15,7 @@ const hotspotType = {
   GO_TO_PREVIOUS: "previous",
   INFORMATION_DIALOG: "information-dialog",
   NONE: "none",
+  GO_TO_SUMMARY_SLIDE: "go-to-summary-slide",
 };
 
 export class Hotspot extends EventDispatcher {
@@ -65,7 +66,9 @@ export class Hotspot extends EventDispatcher {
     );
 
     this.eventDispatcher = new EventDispatcher();
-    const classes = `h5p-press-to-go ${invisible ? "h5p-invisible" : "h5p-visible"}`;
+    const classes = `h5p-press-to-go ${
+      invisible ? "h5p-invisible" : "h5p-visible"
+    }`;
     const tabindex = invisible ? -1 : 0;
 
     if (invisible) {
@@ -94,6 +97,7 @@ export class Hotspot extends EventDispatcher {
       hotspotType.GO_TO_NEXT,
       hotspotType.GO_TO_PREVIOUS,
       hotspotType.GO_TO_SPECIFIED,
+      hotspotType.GO_TO_SUMMARY_SLIDE,
     ];
     const isGoToLink = goToActions.includes(goToSlideType);
     const isInformationDialogTrigger =
@@ -149,6 +153,7 @@ export class Hotspot extends EventDispatcher {
         this.eventDispatcher.on(name, callback);
       };
   }
+
   /**
    * @param {number} goToSlide
    * @param {string} goToSlideType
@@ -159,11 +164,15 @@ export class Hotspot extends EventDispatcher {
     // Default goes to the set number
     let goTo = goToSlide - 1;
 
-    // Check if previous or next is selected.
-    if (goToSlideType === hotspotType.GO_TO_NEXT) {
-      goTo = currentIndex + 1;
-    } else if (goToSlideType === hotspotType.GO_TO_PREVIOUS) {
-      goTo = currentIndex - 1;
+    switch (goToSlideType) {
+      case hotspotType.GO_TO_NEXT:
+        goTo = currentIndex + 1;
+        break;
+      case hotspotType.GO_TO_PREVIOUS:
+        goTo = currentIndex - 1;
+        break;
+      default:
+        break;
     }
 
     // Create button that leads to another slide
@@ -172,7 +181,13 @@ export class Hotspot extends EventDispatcher {
     });
 
     addClickAndKeyboardListeners($element, (event) => {
-      this.eventDispatcher.trigger("navigate", goTo);
+      const isGoToSummarySlideHotspot =
+        goToSlideType === hotspotType.GO_TO_SUMMARY_SLIDE;
+      if (isGoToSummarySlideHotspot) {
+        this.eventDispatcher.trigger("navigate-to-last-slide");
+      } else {
+        this.eventDispatcher.trigger("navigate", goTo);
+      }
       event.preventDefault();
     });
 


### PR DESCRIPTION
This button creates a regular hotspot that has the "Go to summary slide" option set.
The "Go to summary slide" option makes the hotspot point to the last slide,
which will be the summary slide if it exists.

Depends on https://github.com/NDLANO/h5p-editor-course-presentation/pull/41